### PR TITLE
Added useRelativePath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ gulp.task('sass', function() {
 Options
 -------
  - ``baseDir`` : the root path for assets
+ - ``useRelativePath`` : overrides baseDir; root path is relative to the input file's directory
  - ``maxSize`` : define the limit size of injected assets
  - ``debug`` : show debug messages
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = function(opts) {
         var reg_exp = /url\([|\ |\'|\"](.*?)[|\ |\'|\"](|\,(.*?))\)/g;
         var isStream = file.contents && typeof file.contents.on === 'function' && typeof file.contents.pipe === 'function';
         var isBuffer = file.contents instanceof Buffer;
+        if(opts.useRelativePath){
+            app_path = file.path.replace(/\/[^/]+$/, '/');
+        }
         if (isBuffer) {
             var str = String(file.contents);
 


### PR DESCRIPTION
When base64 encoding urls from a stream that contains multiple input
sources, it is helpful to use paths from that source's directory.

This allows you to import separate CSS/SASS projects via npm/bower/etc,
and supply them all as sources in your gulp stream and easily encode
their assets into the output.

Example:

```
gulp.src([
    "node-modules/bootstrap/scss/bootstrap.scss",
    "bower_components/font-awesome/scss/font-awesome.scss",
    "myApp/css/**/_*.scss"])
  .pipe(sass(/*{ ... }*/))
  .pipe(inline_base64({ useRelativePath: true }))
  /* ... */
```

The above will compile each project with urls relative to its own
project.
