### PR TITLE
mime 2.0 renames mime.lookup to mime.getType

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function(opts) {
                         // Else replace by inline base64 version
                         else {
                             var b = fs.readFileSync(filepath);
-                            str = str.replace(matches[i].txt, 'url(' + ('data:' + mime.lookup(filepath) + ';base64,' + b.toString('base64')) + ')');
+                            str = str.replace(matches[i].txt, 'url(' + ('data:' + mime.getType(filepath) + ';base64,' + b.toString('base64')) + ')');
                         }
 
                     } else {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "description": "Convert assets to inline datauri, ideal to integrate small pictures in your css.",
     "main": "index.js",
     "dependencies": {
-        "event-stream": "x.x.x",
-        "gulp-util": "x.x.x",
-        "mime": "x.x.x"
+        "event-stream": "^3.0",
+        "gulp-util": "^3.0",
+        "mime": "^2.0"
     },
     "author": {
         "name": "G33kLabs",


### PR DESCRIPTION
since no version constraints are specified in package.json, mime 2.0 breaks everything.

This PR specifies version constraints and uses mime 2.0